### PR TITLE
Update nix to v0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ build       = "build.rs"
 bitflags    = "1.0"
 lazy_static = "1.0"
 libc        = "0.2"
-nix         = "0.10"
+nix         = "0.19"
 
 [build-dependencies]
 cc              = "1"


### PR DESCRIPTION
nix v0.10 is broken at aarch64-musl platform: https://github.com/nix-rust/nix/issues/951.
So it should be updated to the latest.